### PR TITLE
Fix schema for item stubs with effects

### DIFF
--- a/people/schemas/person_schema_v3.json
+++ b/people/schemas/person_schema_v3.json
@@ -216,7 +216,8 @@
                         "id": {},
                         "effect": {
                             "description": "The new-style status effect ID",
-                            "type": "integer"
+                            "pattern": "[0-9a-z_]+:[0-9a-z_]+",
+                            "type": "string"
                         }
                     },
                     "required": ["id", "effect"]


### PR DESCRIPTION
A new-style effect ID looks like a new-style item ID (`plugin:name`). It is not an integer.
